### PR TITLE
allow build behind firewall blocking ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ RUN apt-get -y install \
       nodejs-legacy \
       npm \
       --no-install-recommends && \
+    git config --global url."https://".insteadOf git:// && \
     cd $SOURCE_DIR && \
     npm install && \
     node_modules/bower/bin/bower install --allow-root && \


### PR DESCRIPTION
Firewalls that block external SSH access make this awkward to build.
This simply makes bower grab everything from GitHub over https instead