### PR TITLE
override host/port for docker pull advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ If you want to run the application with SSL enabled, you can do the following:
     
 Note that the application still serves the port `80` but it is simply not exposed ;). Enable it at your own will. When the application runs with SSL you can open your browser and navigate to [https://localhost][2].
 
+## Use the application as the registry
+
+If you are running the Docker registry on the same host as the application but only accessible to the application (eg. listening on 127.0.0.1) then you can use the application as the registry itself.
+
+Normally this would then give bad advice on how to access a tag:
+
+docker pull localhost:5000/yourname/imagename:latest
+
+We can override what hostname and port to put here:
+
+sudo docker run \
+-d \
+-e ENV_DOCKER_REGISTRY_HOST=localhost \
+-e ENV_DOCKER_REGISTRY_PORT=5000 \
+-e ENV_REGISTRY_PROXY_FQDN=ENTER-YOUR-APPLICATION-HOST-HERE \
+-e ENV_REGISTRY_PROXY_PORT=ENTER-PORT-TO-YOUR-APPLICATION-HOST-HERE \
+-e ENV_USE_SSL=yes \
+-v $PWD/server.crt:/etc/apache2/server.crt:ro \
+-v $PWD/server.key:/etc/apache2/server.key:ro \
+-p 443:443 \
+konradkleine/docker-registry-frontend
+
+A value of 80 or 443 for ENV_REGISTRY_PROXY_PORT will not actually be shown as Docker will check 443 then 80 by default.
+
 ## Kerberos authentication
 
 If you want to use Kerberos to protect access to the registry frontend, you can

--- a/app/views/tag-detail.html
+++ b/app/views/tag-detail.html
@@ -19,8 +19,7 @@
 </h1>
 
 <div class="well">
-  docker pull {{registryHost.host}}<span ng-if="registryHost.port != 80">:{{registryHost.port}}</span>/{{repositoryUser}}/{{repositoryName}}:{{tagName}}
+  docker pull {{registryHost.host}}<span ng-if="registryHost.port != 80 && registryHost.port != 443">:{{registryHost.port}}</span>/{{repositoryUser}}/{{repositoryName}}:{{tagName}}
 </div>
 
 <image-details></image-details>
-

--- a/start-apache.sh
+++ b/start-apache.sh
@@ -7,9 +7,13 @@ die() {
 
 [[ -z "$ENV_DOCKER_REGISTRY_HOST" ]] && die "Missing environment variable: ENV_DOCKER_REGISTRY_HOST=url-to-your-registry" 
 [[ -z "$ENV_DOCKER_REGISTRY_PORT" ]] && ENV_DOCKER_REGISTRY_PORT=80 
+[[ -z "$ENV_REGISTRY_PROXY_FQDN" ]] && ENV_REGISTRY_PROXY_FQDN=$ENV_DOCKER_REGISTRY_HOST
+[[ -z "$ENV_REGISTRY_PROXY_PORT" ]] && ENV_REGISTRY_PROXY_PORT=$ENV_DOCKER_REGISTRY_PORT
 
 echo "export DOCKER_REGISTRY_HOST=$ENV_DOCKER_REGISTRY_HOST" >> /etc/apache2/envvars
 echo "export DOCKER_REGISTRY_PORT=$ENV_DOCKER_REGISTRY_PORT" >> /etc/apache2/envvars
+echo "export REGISTRY_PROXY_FQDN=$ENV_REGISTRY_PROXY_FQDN" >> /etc/apache2/envvars
+echo "export REGISTRY_PROXY_PORT=$ENV_REGISTRY_PROXY_PORT" >> /etc/apache2/envvars
 
 needModSsl=0
 if [ -n "$ENV_DOCKER_REGISTRY_USE_SSL" ]; then
@@ -19,9 +23,9 @@ else
   echo "export DOCKER_REGISTRY_SCHEME=http" >> /etc/apache2/envvars
 fi
 
-# Build the JSON file which is read by JS to retrieve
-# information about how to contact the registry.
-echo "{\"host\": \"$ENV_DOCKER_REGISTRY_HOST\", \"port\": $ENV_DOCKER_REGISTRY_PORT}" > /var/www/html/registry-host.json
+# docker-registry-frontend acts as a proxy so may well
+# have a different hostname than the registry itself.
+echo "{\"host\": \"$ENV_REGISTRY_PROXY_FQDN\", \"port\": $ENV_REGISTRY_PROXY_PORT}" > /var/www/html/registry-host.json
 
 # Optionally enable Kerberos authentication and do some parameter checks
 if [ -n "$ENV_AUTH_USE_KERBEROS" ]; then


### PR DESCRIPTION
The docker pull advice on the tag detail page can be incorrect if you are proxying to localhost.
This allows you to override the values but takes the previous settings as default.
Also doesn't display port 443 as that is Dockers default registry port before falling back to port 80.