### PR TITLE
Include port if host is not an FQDN

### DIFF
--- a/app/views/tag-detail.html
+++ b/app/views/tag-detail.html
@@ -19,7 +19,7 @@
 </h1>
 
 <div class="well">
-  docker pull {{registryHost.host}}<span ng-if="registryHost.port != 80 && registryHost.port != 443">:{{registryHost.port}}</span>/{{repositoryUser}}/{{repositoryName}}:{{tagName}}
+  docker pull {{registryHost.host}}<span ng-if="registryHost.host.indexOf('.') == -1 || (registryHost.port != 80 && registryHost.port != 443)">:{{registryHost.port}}</span>/{{repositoryUser}}/{{repositoryName}}:{{tagName}}
 </div>
 
 <image-details></image-details>


### PR DESCRIPTION
Docker looks for a '.' or ':' in first part of the tag to determine if it's a host or username.
If ENV_REGISTRY_PROXY_FQDN was specified as a short name and port is either 80 or 443, that meant the frontend would generate a pull command like `docker pull short-name/library/image:tag` which is wrong.
