### PR TITLE
Support for Basic Authentiocation added. Users need to set ENV_AUTH_USE_...

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ do the followiung:
 
 You can of course combine SSL and Kerberos.
 
+## Basic authentication
+
+If you want to use Basic Authentication to protect repos/tags management feature in the UI, you can specify `ENV_AUTH_USE_BASIC` and volume flags as follows:
+
+    sudo docker run \
+      -d \
+      -e ENV_DOCKER_REGISTRY_HOST=ENTER-YOUR-REGISTRY-HOST-HERE \
+      -e ENV_DOCKER_REGISTRY_PORT=ENTER-PORT-TO-YOUR-REGISTRY-HERE \
+      -e ENV_AUTH_USE_BASIC=yes \
+      -v $PWD/docker-registry.htpasswd:/etc/apache2/docker-registry.htpasswd:ro \
+      -p 8080:80 \
+      konradkleine/docker-registry-frontend
+
+You can of course combine SSL and Basic Authentication.
+
 # Browse mode
 
 If you want to start applicaton with browse mode which means no repos/tags management feature in the UI, You can specify `ENV_MODE_BROWSE_ONLY` flag as follows:

--- a/apache-site.conf
+++ b/apache-site.conf
@@ -15,6 +15,17 @@
       </LimitExcept>
     </Location>
   </IfDefine>
+ 
+  <IfDefine BASIC_AUTH>
+   <Location /> 
+     <LimitExcept GET>
+         AuthName "Docker registry frontend authentication."
+         AuthType basic
+         AuthUserFile /etc/apache2/docker-registry.htpasswd 
+         Require valid-user
+     </LimitExcept>
+   </Location>
+  </IfDefine>
 
   # Proxy all docker REST API registry
   # requests to the docker registry server.

--- a/start-apache.sh
+++ b/start-apache.sh
@@ -34,6 +34,13 @@ if [ "$ENV_MODE_BROWSE_ONLY" == "true" ]; then
   echo "export APACHE_ARGUMENTS='-D FRONTEND_BROWSE_ONLY_MODE'" >> /etc/apache2/envvars
 fi
 
+# Optionally enable basic authentication and do some parameter checks
+if [ -n "$ENV_AUTH_USE_BASIC" ]; then
+  useBAuth="-D BASIC_AUTH"
+
+   [[ ! -e /etc/apache2/docker-registry.htpasswd ]] && die "/etc/apache2/docker-registry.htpasswd is missing"
+fi
+
 # Optionally enable Kerberos authentication and do some parameter checks
 if [ -n "$ENV_AUTH_USE_KERBEROS" ]; then
 
@@ -68,4 +75,4 @@ else
   a2dismod ssl
 fi
 
-/usr/sbin/apache2ctl -D FOREGROUND ${useSsl}
+/usr/sbin/apache2ctl -D FOREGROUND ${useSsl} ${useBAuth}


### PR DESCRIPTION
...BASIC and volume for htpasswd

Enable Basic Authentication for repos/tags management in the UI.