### PR TITLE
Setting ProxyPreserveHost to its default value: Off

### DIFF
--- a/apache-site.conf
+++ b/apache-site.conf
@@ -43,7 +43,7 @@
      SSLProxyCheckPeerCN off
      SSLProxyCheckPeerName off
   </IfModule>
-  ProxyPreserveHost On
+  ProxyPreserveHost Off
   ProxyPass /v2/ ${DOCKER_REGISTRY_SCHEME}://${DOCKER_REGISTRY_HOST}:${DOCKER_REGISTRY_PORT}/v2/
   ProxyPassReverse /v2/ ${DOCKER_REGISTRY_SCHEME}://${DOCKER_REGISTRY_HOST}:${DOCKER_REGISTRY_PORT}/v2/
 


### PR DESCRIPTION
I never see the repos if this setting is set to on.  By default, mod_proxy recommends that it should be off: https://httpd.apache.org/docs/2.4/mod/mod_proxy.html.

"This option should normally be turned Off. It is mostly useful in special configurations like proxied mass name-based virtual hosting, where the original Host header needs to be evaluated by the backend server."
