### PR TITLE
downgrade grunt-contrib-connect 0.10.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-connect-proxy": "^0.2.0",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-connect": "^0.11.2",
+    "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-cssmin": "^0.14.0",
     "grunt-contrib-htmlmin": "^0.6.0",


### PR DESCRIPTION
downgrade grunt-contrib-connect to version 0.10.1 because of changes … in connect 3.x.
this causes an error while upstart:

> Warning: Object function createServer() {
>   function app(req, res, next){ app.handle(req, res, next); }
>   merge(app, proto);
>   merge(app, EventEmitter.prototype);
>   app.route = '/';
>   app.stack = [];
>   return app;
> } has no method 'static' Use --force to continue.
> Aborted due to warnings.
