### PR TITLE
Support for repos without username

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -64,6 +64,10 @@ angular
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryDetailController',
       }).
+      when('/repository/:repositoryName', {
+        templateUrl: 'repository/repository-detail.html',
+       controller: 'RepositoryDetailController',
+      }).
       when('/repository/:repositoryUser/:repositoryName/tags/:searchName?', {
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryController',


### PR DESCRIPTION
The merge will supprt both ways of routing.
With and without username.

> http://localhost:9000/repository/databases/mysql

and

> http://localhost:9000/repository/mysql
