### PR TITLE
Add support for v2 registry w/o namespace

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -68,6 +68,14 @@ angular
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryController',
       }).
+      when('/repository/:repositoryName', {
+        templateUrl: 'repository/repository-detail.html',
+        controller: 'RepositoryDetailController',
+      }).
+      when('/repository/:repositoryName/tags/:searchName?', {
+        templateUrl: 'repository/repository-detail.html',
+        controller: 'RepositoryController',
+      }).
 	    when('/about', {
         templateUrl: 'about.html',
       }).

--- a/app/app.js
+++ b/app/app.js
@@ -60,19 +60,11 @@ angular
         templateUrl: 'repository/repository-list.html',
         controller: 'RepositoryListController'
       }).
-      when('/repository/:repositoryUser/:repositoryName', {
+      when('/repository/:repositoryUser?/:repositoryName', {
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryDetailController',
       }).
-      when('/repository/:repositoryUser/:repositoryName/tags/:searchName?', {
-        templateUrl: 'repository/repository-detail.html',
-        controller: 'RepositoryController',
-      }).
-      when('/repository/:repositoryName', {
-        templateUrl: 'repository/repository-detail.html',
-        controller: 'RepositoryDetailController',
-      }).
-      when('/repository/:repositoryName/tags/:searchName?', {
+      when('/repository/:repositoryUser?/:repositoryName/tags/:searchName?', {
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryController',
       }).

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -1,13 +1,14 @@
 <ol class="breadcrumb">
     <li><a href="home">Home</a></li>
     <li><a href="repositories/">Repositories</a></li>
-    <li><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
-    <li><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a></li>
+    <li ng-show="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
+    <li ng-show="repositoryUser"><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a></li>
+    <li ng-hide="repositoryUser"><a href="repository/{{repositoryName}}">{{repositoryName}}</a></li>
 </ol>
 
 <h1>
   Details for repository
-  <a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a>/<a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a>
+  <span ng-hide="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a>/</span><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a>
   <div ng-hide="appMode.browseOnly" class="pull-right">
     <!-- Maybe put this into its own directive? -->
     <button type="button" ng-click="selectedRepositories=['{{repositoryUser}}/{{repositoryName}}']; openConfirmRepoDeletionDialog()" class="btn btn-danger" ng-hide="appMode.browseOnly">

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -8,7 +8,7 @@
 
 <h1>
   Details for repository
-  <span ng-hide="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a>/</span><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a>
+  <span ng-show="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a>/</span><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a>
   <div ng-hide="appMode.browseOnly" class="pull-right">
     <!-- Maybe put this into its own directive? -->
     <button type="button" ng-click="selectedRepositories=['{{repositoryUser}}/{{repositoryName}}']; openConfirmRepoDeletionDialog()" class="btn btn-danger" ng-hide="appMode.browseOnly">


### PR DESCRIPTION
When an image has been uploaded to a V2 registry, without a namespace.

This PR should allow users to still be able to view these images.

This is my first time working on an AngularJS project so, feel free to reject or implement in a better way.
Feedback is appreciated.

Index view:
<img width="1172" alt="screen shot 2016-02-05 at 8 05 10 pm" src="https://cloud.githubusercontent.com/assets/1504448/12857741/c9b9e1bc-cc43-11e5-9b59-a1510a6bb3f8.png">

Without Namespace: /repository/redis
<img width="512" alt="screen shot 2016-02-05 at 8 18 59 pm" src="https://cloud.githubusercontent.com/assets/1504448/12858072/be07f06e-cc45-11e5-9572-3d5fd88d0f25.png">

With Namespace: /repository/test/redis
<img width="591" alt="screen shot 2016-02-05 at 8 19 49 pm" src="https://cloud.githubusercontent.com/assets/1504448/12858088/d178d64a-cc45-11e5-9bdc-d3792a7db2a8.png">
