### PR TITLE
Fix delayed / slow push using Docker 10.x

### DIFF
--- a/apache-site.conf
+++ b/apache-site.conf
@@ -85,4 +85,9 @@
     Allow from all
   </Location>
 
+  # Reject access to /v2.
+  # NOTE: By rejecting /v2 Docker will fall back on /v1.
+  <Location /v2>
+    Deny from all
+  </Location>
 </VirtualHost>


### PR DESCRIPTION
**Note:** This issue only occurs if `docker-registry-fronted` is also used as registry interface.

Docker 10.x tries to contact a registry using `/v2` first. If `/v2` fails it falls back to `/v1`. If the request succeeds but the response is unexpected (Like in the case of `docker-registry-fronted`). Docker retries the request several times prior falling back to `/v1`. Furthermore Docker waits several seconds between retries. This patch solves this issue and improves compatibility with the current Docker release.
