### PR TITLE
Fix development environment.

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER "Konrad Kleine"
 
 USER root
@@ -38,6 +38,8 @@ RUN apt-get -y install \
 RUN git config --global url."https://".insteadOf git://
 # Avoid this: "Problem with the SSL CA cert (path? access rights?)"
 RUN git config --global http.sslVerify false
+RUN npm install -g bower
+RUN npm install -g grunt
 
 ############################################################
 # Create start script

--- a/develop/start-develop.sh
+++ b/develop/start-develop.sh
@@ -3,5 +3,5 @@ set -x
 set -e
 cd $SOURCE_DIR
 npm install
-node_modules/bower/bin/bower install --allow-root
-node_modules/grunt-cli/bin/grunt serve --allow-root
+bower install --allow-root
+grunt serve --allow-root


### PR DESCRIPTION
On a fresh clone the development environment was broken due to
broken bower and grunt installed in the container. This has been
resolved by:
1. Updating the container to Ubuntu 16.04 which has updated
   versions of node and npm in its repositories.
2. Change the docker container build to install grunt and
   bower globally.
