### PR TITLE
Fix issues with repository list pagination.

### DIFF
--- a/app/repository/repository-list.html
+++ b/app/repository/repository-list.html
@@ -49,7 +49,7 @@
 
 <nav>
   <ul class="pager">
-    <li class="previous" ng-class="{disabled: !lastNamespace || !lastRepository}">
+    <li class="previous">
       <a href="repositories/{{reposPerPage}}">
         <span aria-hidden="true">&larr;</span>
         First page
@@ -64,7 +64,6 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="repositories">Show all</a></li>
           <li role="separator" class="divider"></li>
           <li><a href="repositories/10">10</a></li>
           <li><a href="repositories/20">20</a></li>
@@ -75,10 +74,8 @@
         </ul>
       </div>
     </li>
-    <li class="next" ng-class="{disabled: !repositories.lastNamespace || !repositories.lastRepository}">
-      <!-- TODO: Make sure the button is not clickable -->
-      <a href="/repositories/{{reposPerPage}}/{{repositories.lastNamespace}}/{{repositories.lastRepository}}"
-        ng-disabled="!repositories.lastNamespace || !repositories.lastRepository">
+    <li class="next btn" ng-hide="lastPage">
+      <a ng-click="nextPage()">
         Next <span aria-hidden="true">&rarr;</span>
       </a>
     </li>

--- a/app/services/registry-services.js
+++ b/app/services/registry-services.js
@@ -41,45 +41,11 @@ angular.module('registry-services', ['ngResource'])
         transformResponse: function(data, headers){
           var repos = angular.fromJson(data).repositories;
 
-          // Extract the "last=" part from Link header:
-          //
-          //   Link: </v2/_catalog?last=namespace%2repository&n=10>; rel="next"
-          //
-          // We only want to extrace the "last" part and store it like this
-          //
-          //   lastNamespace = namespace
-          //   lastRepository = repository
-          //
-          // TODO: Can we clean this up a bit?
-          var last = undefined;
-          var lastNamespace = undefined;
-          var lastRepository = undefined;
-          var linkHeader = headers()['link'];
-          //console.log('linkHeader='+linkHeader);
-          if (linkHeader) {
-            var lastUrl = ''+linkHeader.split(';')[0].replace('<','').replace('>','');
-            var startPos = lastUrl.search('last=');
-            //console.log('startPos=' + startPos);
-            if (startPos >= 0) {
-              var endPos = lastUrl.substring(startPos).search('&');
-              //console.log('endPos=' + endPos);
-              if (endPos >= 0) {
-                last = lastUrl.substring(startPos+'last='.length, startPos+endPos);
-                //console.log('last=' + last);
-                var parts = last.split('%2F');
-                //console.log('parts=' + parts);
-                if (parts.length == 2) {
-                  lastNamespace = parts[0];
-                  lastRepository = parts[1];
-                }
-              }
-            }
-          }
+          var hasLinkHeader = typeof headers()['link'] !== 'undefined';
 
           var ret = {
             repos: [],
-            lastNamespace: lastNamespace,
-            lastRepository: lastRepository
+            lastPage: !hasLinkHeader
           };
 
           angular.forEach(repos, function(value/*, key*/) {


### PR DESCRIPTION
Pagination had a few bugs:
    1. The 'next' button would be improperly disabled in most cases.
    2. The 'last page' button would be improperly disabled in most cases.
    3. The 'last' repository would not be properly selected when picking
        the 'next' button.
    4. The listing did not properly deal with situations where a repository
        only has a 'name' (i.e. "myrepo" vs "jonathanhood/myrepo"). The code
        has been updated to deal with both cases appropriately.
    5. The "link" header parsing has been removed in favor of some simpler
        behavior. The link header is only used to check if this page is
        the last page and is thrown away. The proper 'last' repository
        is now calculated based on the returned array instead, which was
        simpler than parsing it out.
