### PR TITLE
Fix the swithching of reposPerPage

### DIFF
--- a/app/repository/repository-list-controller.js
+++ b/app/repository/repository-list-controller.js
@@ -43,6 +43,10 @@ angular.module('repository-list-controller', ['registry-services', 'app-mode-ser
       return filterFilter($scope.repositories.repos, { selected: true });
     };
 
+    $scope.page = function(num){
+      $location.path("repositories/" + num + "/" + $scope.lastNamespace + "/" + $scope.lastRepository);
+    }
+
     // Watch repos for changes
     // To watch for changes on a property inside the object "repositories"
     // we first have to make sure the promise is ready.

--- a/app/repository/repository-list.html
+++ b/app/repository/repository-list.html
@@ -66,12 +66,12 @@
         <ul class="dropdown-menu">
           <li><a href="repositories">Show all</a></li>
           <li role="separator" class="divider"></li>
-          <li><a href="repositories/10">10</a></li>
-          <li><a href="repositories/20">20</a></li>
-          <li><a href="repositories/40">40</a></li>
-          <li><a href="repositories/60">60</a></li>
-          <li><a href="repositories/80">80</a></li>
-          <li><a href="repositories/100">100</a></li>
+          <li><a href="" ng-click="page(10)">10</a></li>
+          <li><a href="" ng-click="page(20)">20</a></li>
+          <li><a href="" ng-click="page(40)">40</a></li>
+          <li><a href="" ng-click="page(60)">60</a></li>
+          <li><a href="" ng-click="page(80)">80</a></li>
+          <li><a href="" ng-click="page(100)">100</a></li>
         </ul>
       </div>
     </li>


### PR DESCRIPTION
After switching reposPerPage, the first repos in the new page should remain the same.

Signed-off-by: lijun lijun@qiyi.com
