### PR TITLE
delay tag item showing until its manifest received

### DIFF
--- a/app/tag/tag-list-directive.html
+++ b/app/tag/tag-list-directive.html
@@ -23,7 +23,7 @@
 		  </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="tag in displayedTags | filter:search ">
+      <tr ng-repeat="tag in displayedTags | filter:search " ng-show="tag.details">
         <td>
           <a ng-bind-html="tag.name" href="tag/{{repositoryUser}}/{{repositoryName}}/{{tag.name}}">{{tag.name}}</a>
         </td>


### PR DESCRIPTION
For a tag item, there exists a time interval between receiving its name and its manifest.
That will result in some jitter when loading.

Signed-off-by: lijun lijun@qiyi.com
