### PR TITLE
develop/README.md: Fix link

### DIFF
--- a/develop/README.md
+++ b/develop/README.md
@@ -29,6 +29,7 @@ Kill all potentially running frontend or registry containers:
 
 Then open [develop/docker-compose.yml](docker-compose.yml) and paste this into the file:
 
+```yaml
     frontend:
       build: .
       ports:
@@ -36,6 +37,7 @@ Then open [develop/docker-compose.yml](docker-compose.yml) and paste this into t
       volumes:
         - ../:/source:rw
         - ./start-develop.sh:/root/start-develop.sh:ro
+```
 
 Notice that we removed the `links` section from the `frontend` section and that the `registry` section is completely gone.
 

--- a/develop/README.md
+++ b/develop/README.md
@@ -41,7 +41,7 @@ Then open [develop/docker-compose.yml](docker-compose.yml) and paste this into t
 
 Notice that we removed the `links` section from the `frontend` section and that the `registry` section is completely gone.
 
-Now open [Gruntfile.js](Gruntfile.js) and find these lines:
+Now open [Gruntfile.js](../Gruntfile.js) and find these lines:
 
         {
           context: '/v2',

--- a/develop/README.md
+++ b/develop/README.md
@@ -43,6 +43,7 @@ Notice that we removed the `links` section from the `frontend` section and that 
 
 Now open [Gruntfile.js](../Gruntfile.js) and find these lines:
 
+```javascript
         {
           context: '/v2',
           host: 'path-to-your-registry-v2',
@@ -53,6 +54,7 @@ Now open [Gruntfile.js](../Gruntfile.js) and find these lines:
             "x-custom-added-header": 'custom-value'
           }
         }
+```
 
 Adjust them to your liking and replace `path-to-your-registry` with the IP address or hostname of your own registry. I suggest to use the IP address; otherwise your development container might have hard time resolving the domain.
 

--- a/develop/README.md
+++ b/develop/README.md
@@ -27,7 +27,7 @@ Kill all potentially running frontend or registry containers:
 
     docker-compose -f docker-registry-frontend/develop/docker-compose.yml kill
 
-Then open (develop/docker-compose.yml)[develop/docker-compose.yml] and paste this into the file:
+Then open [develop/docker-compose.yml](docker-compose.yml) and paste this into the file:
 
     frontend:
       build: .


### PR DESCRIPTION
Fix link to develop/docker-compose.yml which had square brackets and
parentheses interchanged.

https://github.com/msabramo/docker-registry-frontend/blob/develop_doc_fix_link/develop/README.md
