### PR TITLE
Gruntfile.js: Use DOCKER_REGISTRY_{HOST,PORT}

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,8 +79,8 @@ module.exports = function (grunt) {
       proxies: [
         {
           context: '/v2',
-          host: 'path-to-your-registry-v2',
-          port: 5000,
+          host: process.env.DOCKER_REGISTRY_HOST,
+          port: process.env.DOCKER_REGISTRY_PORT,
           https: false,
           xforward: false,
           headers: {


### PR DESCRIPTION
Use `DOCKER_REGISTRY_HOST` and `DOCKER_REGISTRY_PORT` environment
variables so that one can specify a custom Docker registry server while
developing, without hacking `Gruntfile.js`.
