### PR TITLE
Handle images with no user properly

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -75,7 +75,7 @@ angular
 	    when('/about', {
         templateUrl: 'about.html',
       }).
-      when('/tag/:repositoryUser/:repositoryName/:tagName/', {
+      when('/tag/:repositoryUser?/:repositoryName/:tagName/', {
         templateUrl: 'tag/tag-detail.html',
         controller: 'TagController',
       }).

--- a/app/app.js
+++ b/app/app.js
@@ -60,11 +60,11 @@ angular
         templateUrl: 'repository/repository-list.html',
         controller: 'RepositoryListController'
       }).
-      when('/repository/:repositoryUser/:repositoryName/:tagsPerPage?/:tagPage?', {
+      when('/repository/:repositoryUser/:repositoryName', {
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryDetailController'
       }).
-      when('/repository/:repositoryName/:tagsPerPage?/:tagPage?', {
+      when('/repository/:repositoryName', {
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryDetailController'
       }).

--- a/app/app.js
+++ b/app/app.js
@@ -60,11 +60,11 @@ angular
         templateUrl: 'repository/repository-list.html',
         controller: 'RepositoryListController'
       }).
-      when('/repository/:repositoryUser/:repositoryName', {
-        templateUrl: 'repository/repository-detail.html',
-        controller: 'RepositoryDetailController',
-      }).
       when('/repository/:repositoryUser/:repositoryName/:tagsPerPage?/:tagPage?', {
+        templateUrl: 'repository/repository-detail.html',
+        controller: 'RepositoryDetailController'
+      }).
+      when('/repository/:repositoryName/:tagsPerPage?/:tagPage?', {
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryDetailController'
       }).

--- a/app/app.spec.js
+++ b/app/app.spec.js
@@ -80,7 +80,8 @@ describe('docker-registry-frontend', function() {
 
   it('URL with repositoryUser and repositoryName and tagsPerPage should display repository detail page', function() {
     $httpBackend.expectGET('repository/repository-detail.html').respond(200);
-    $location.path('/repository/owner/name/10');
+    $location.path('/repository/owner/name');
+    $location.search('tagsPerPage', 10)
     $rootScope.$digest();
     expect($route.current.templateUrl).toBe('repository/repository-detail.html');
     expect($route.current.controller).toBe('RepositoryDetailController');
@@ -91,9 +92,6 @@ describe('docker-registry-frontend', function() {
     expect(scope.repository).toBe('owner/name');
   });
 
-  // This test currently fails; this URL is incorrectly routing to the home page
-  // @todo @FIXME
-  //
   it('URL with repositoryName but no repositoryUser and no tagsPerPage should display repository detail page', function() {
     $httpBackend.expectGET('repository/repository-detail.html').respond(200);
     $location.path('/repository/cx');
@@ -104,15 +102,16 @@ describe('docker-registry-frontend', function() {
 
   it('URL with repositoryName but no repositoryUser and tagsPerPage should display repository detail page', function() {
     $httpBackend.expectGET('repository/repository-detail.html').respond(200);
-    $location.path('/repository/cx/10');
+    $location.path('/repository/cx');
+    $location.search('tagsPerPage', 10)
     $rootScope.$digest();
     expect($route.current.templateUrl).toBe('repository/repository-detail.html');
     expect($route.current.controller).toBe('RepositoryDetailController');
     var scope = {};
     $controller('RepositoryDetailController', {$scope: scope});
-    // expect(scope.repositoryUser).toBeUndefined();
-    // expect(scope.repositoryName).toBe('cx');
-    // expect(scope.repository).toBe('cx');
+    expect(scope.repositoryUser).toBeUndefined();
+    expect(scope.repositoryName).toBe('cx');
+    expect(scope.repository).toBe('cx');
   });
 
   it('/about should display about page', function() {

--- a/app/app.spec.js
+++ b/app/app.spec.js
@@ -135,16 +135,13 @@ describe('docker-registry-frontend', function() {
     expect(scope.tagName).toBe('latest');
   });
 
-  // This test currently fails; this URL is incorrectly routing to the home page
-  // @todo @FIXME
-  //
-  // it('/tag/repositoryName/latest should display tag detail page', function() {
-  //   $httpBackend.expectGET('tag/tag-detail.html').respond(200);
-  //   $location.path('/tag/repositoryName/latest');
-  //   $rootScope.$digest();
-  //   expect($route.current.templateUrl).toBe('tag/tag-detail.html');
-  //   expect($route.current.controller).toBe('TagController');
-  // });
+  it('/tag/repositoryName/latest should display tag detail page', function() {
+    $httpBackend.expectGET('tag/tag-detail.html').respond(200);
+    $location.path('/tag/repositoryName/latest');
+    $rootScope.$digest();
+    expect($route.current.templateUrl).toBe('tag/tag-detail.html');
+    expect($route.current.controller).toBe('TagController');
+  });
 
   it('/image/88e37c7099fa should display image detail page', function() {
     $httpBackend.expectGET('tag/image-detail.html').respond(200);

--- a/app/app.spec.js
+++ b/app/app.spec.js
@@ -94,13 +94,13 @@ describe('docker-registry-frontend', function() {
   // This test currently fails; this URL is incorrectly routing to the home page
   // @todo @FIXME
   //
-  // it('URL with repositoryName but no repositoryUser and no tagsPerPage should display repository detail page', function() {
-  //   $httpBackend.expectGET('repository/repository-detail.html').respond(200);
-  //   $location.path('/repository/cx');
-  //   $rootScope.$digest();
-  //   expect($route.current.templateUrl).toBe('repository/repository-detail.html');
-  //   expect($route.current.controller).toBe('RepositoryDetailController');
-  // });
+  it('URL with repositoryName but no repositoryUser and no tagsPerPage should display repository detail page', function() {
+    $httpBackend.expectGET('repository/repository-detail.html').respond(200);
+    $location.path('/repository/cx');
+    $rootScope.$digest();
+    expect($route.current.templateUrl).toBe('repository/repository-detail.html');
+    expect($route.current.controller).toBe('RepositoryDetailController');
+  });
 
   it('URL with repositoryName but no repositoryUser and tagsPerPage should display repository detail page', function() {
     $httpBackend.expectGET('repository/repository-detail.html').respond(200);

--- a/app/app.spec.js
+++ b/app/app.spec.js
@@ -50,7 +50,7 @@ describe('docker-registry-frontend', function() {
     expect($route.current.controller).toBe('RepositoryListController');
     var scope = {};
     $controller('RepositoryListController', {$scope: scope});
-    // expect(scope.reposPerPage).toBe(10);
+    expect(scope.reposPerPage).toBe(10);
   });
 
   it('/repositories/20 should display repository list page', function() {
@@ -61,7 +61,7 @@ describe('docker-registry-frontend', function() {
     expect($route.current.controller).toBe('RepositoryListController');
     var scope = {};
     $controller('RepositoryListController', {$scope: scope});
-    // expect(scope.reposPerPage).toBe(20);
+    expect(scope.reposPerPage).toBe(20);
   });
 
   it('URL with repositoryUser and repositoryName and no tagsPerPage should display repository detail page', function() {

--- a/app/repository/repository-detail-controller.js
+++ b/app/repository/repository-detail-controller.js
@@ -8,8 +8,8 @@
  * Controller of the docker-registry-frontend
  */
 angular.module('repository-detail-controller', ['registry-services', 'app-mode-services'])
-  .controller('RepositoryDetailController', ['$scope', '$route', '$routeParams', '$location', '$modal', 'Repository', 'AppMode',
-  function($scope, $route, $routeParams, $location, $modal, Repository, AppMode){
+  .controller('RepositoryDetailController', ['$scope', '$route', '$routeParams', '$location', '$log', '$modal', 'Repository', 'AppMode',
+  function($scope, $route, $routeParams, $location, $log, $modal, Repository, AppMode){
 
     $scope.$route = $route;
     $scope.$location = $location;

--- a/app/repository/repository-detail-controller.js
+++ b/app/repository/repository-detail-controller.js
@@ -18,7 +18,14 @@ angular.module('repository-detail-controller', ['registry-services', 'app-mode-s
     //$scope.searchTerm = $route.current.params.searchTerm;
     $scope.repositoryUser = $route.current.params.repositoryUser;
     $scope.repositoryName = $route.current.params.repositoryName;
-    $scope.repository = $scope.repositoryUser + '/' + $scope.repositoryName;
+    $log.log('repository-detail-controller: $scope.repositoryUser = ' + $scope.repositoryUser);
+    if ($scope.repositoryUser == null || $scope.repositoryUser == 'undefined') {
+      $scope.repository = $scope.repositoryName;
+      $log.log('repository-detail-controller: $scope.repositoryUser was undefined; setting repository to just repositoryName = ' + $scope.repository);
+    } else {
+      $scope.repository = $scope.repositoryUser + '/' + $scope.repositoryName;
+      $log.log('repository-detail-controller: $scope.repositoryUser was NOT undefined; setting repository to ' + $scope.repository);
+    }
 
     $scope.appMode = AppMode.query();
     $scope.maxTagsPage = undefined;

--- a/app/repository/repository-detail-controller.js
+++ b/app/repository/repository-detail-controller.js
@@ -34,13 +34,13 @@ angular.module('repository-detail-controller', ['registry-services', 'app-mode-s
     $scope.getNextHref = function (){
       if($scope.maxTagsPage > $scope.tagsCurrentPage){
         var nextPageNumber = $scope.tagsCurrentPage + 1;
-        return '/repository/'+$scope.repository+'/'+ $scope.tagsPerPage +'/' +nextPageNumber;
+        return '/repository/'+$scope.repository+'?tagsPerPage='+ $scope.tagsPerPage +'&tagPage=' +nextPageNumber;
       }
       return '#'
-    } 
+    }
     $scope.getFirstHref = function (){
       if($scope.tagsCurrentPage > 1){
-        return '/repository/'+$scope.repository+'/' + $scope.tagsPerPage +'/1';
+        return '/repository/'+$scope.repository+'?tagsPerPage=' + $scope.tagsPerPage;
       }
       return '#'
     }

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -42,12 +42,12 @@
         <ul class="dropdown-menu">
           <li><a href="repository/{{repository}}">Show all</a></li>
           <li role="separator" class="divider"></li>
-          <li><a href="repository/{{repository}}/10/1">10</a></li>
-          <li><a href="repository/{{repository}}/20/1">20</a></li>
-          <li><a href="repository/{{repository}}/40/1">40</a></li>
-          <li><a href="repository/{{repository}}/60/1">60</a></li>
-          <li><a href="repository/{{repository}}/80/1">80</a></li>
-          <li><a href="repository/{{repository}}/100/1">100</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=10">10</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=20">20</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=40">40</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=60">60</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=80">80</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=100">100</a></li>
         </ul>
       </div>
     </li>

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -6,8 +6,7 @@
 </ol>
 
 <h1>
-  Details for repository
-  <a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a>/<a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a>
+  Details for repository: {{repository}}
   <div ng-hide="appMode.browseOnly" class="pull-right">
     <!-- Maybe put this into its own directive? -->
     <button type="button" ng-click="selectedRepositories=['{{repositoryUser}}/{{repositoryName}}']; openConfirmRepoDeletionDialog()" class="btn btn-danger" ng-hide="appMode.browseOnly">

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -40,7 +40,7 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="repository/{{repository}}">Show all</a></li>
+          <li><a href="repository/{{repository}}?tagsPerPage=all">Show all</a></li>
           <li role="separator" class="divider"></li>
           <li><a href="repository/{{repository}}?tagsPerPage=10">10</a></li>
           <li><a href="repository/{{repository}}?tagsPerPage=20">20</a></li>

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -1,7 +1,7 @@
 <ol class="breadcrumb">
     <li><a href="home">Home</a></li>
     <li><a href="repositories/">Repositories</a></li>
-    <li><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
+    <li ng-show="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
     <li><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a></li>
 </ol>
 

--- a/app/repository/repository-detail.html
+++ b/app/repository/repository-detail.html
@@ -2,7 +2,7 @@
     <li><a href="home">Home</a></li>
     <li><a href="repositories/">Repositories</a></li>
     <li ng-show="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
-    <li><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a></li>
+    <li><a href="repository/{{repository}}">{{repositoryName}}</a></li>
 </ol>
 
 <h1>

--- a/app/repository/repository-list-controller.js
+++ b/app/repository/repository-list-controller.js
@@ -19,8 +19,8 @@ angular.module('repository-list-controller', ['ngRoute', 'ui.bootstrap', 'regist
     $scope.repositoryName = $route.current.params.repositoryName;
     $scope.repository = $scope.repositoryUser + '/' + $scope.repositoryName;
 
-    $scope.appMode = AppMode.query( function (result){
-      $scope.defaultTagsPerPage = result.defaultTagsPerPage
+    AppMode.query(function(result) {
+      $scope.appMode = result;
     });
     // How to query the repository
     $scope.reposPerPage = $route.current.params.reposPerPage;

--- a/app/repository/repository-list-controller.js
+++ b/app/repository/repository-list-controller.js
@@ -23,7 +23,9 @@ angular.module('repository-list-controller', ['ngRoute', 'ui.bootstrap', 'regist
       $scope.appMode = result;
     });
     // How to query the repository
-    $scope.reposPerPage = $route.current.params.reposPerPage;
+    if ($route.current.params.reposPerPage) {
+      $scope.reposPerPage = parseInt($route.current.params.reposPerPage, 10);
+    }
     $scope.lastNamespace = $route.current.params.lastNamespace;
     $scope.lastRepository = $route.current.params.lastRepository;
     var queryObject = {};

--- a/app/repository/repository-list.html
+++ b/app/repository/repository-list.html
@@ -38,7 +38,7 @@
           <!--<input type="checkbox" name="selectedRepos[]" value="{{repo.name}}" ng-model="repo.selected" ng-hide="appMode.browseOnly">-->
         </td>
         <td class="grow">
-          <a href="repository/{{repo.name}}/{{defaultTagsPerPage}}"><!--<span class="glyphicon glyphicon-book"></span>--> {{repo.name|trim:username+'/'}}</a>
+          <a href="repository/{{repo.name}}"><!--<span class="glyphicon glyphicon-book"></span>--> {{repo.name|trim:username+'/'}}</a>
         </td>
       </tr>
     </tbody>

--- a/app/tag/tag-controller.js
+++ b/app/tag/tag-controller.js
@@ -18,7 +18,14 @@ angular.module('tag-controller', ['registry-services'])
     $scope.searchName = $route.current.params.searchName;
     $scope.repositoryUser = $route.current.params.repositoryUser;
     $scope.repositoryName = $route.current.params.repositoryName;
-    $scope.repository = $scope.repositoryUser + '/' + $scope.repositoryName;
+    $log.log('tag-controller: $scope.repositoryUser = ' + $scope.repositoryUser);
+    if ($scope.repositoryUser == null || $scope.repositoryUser == 'undefined') {
+      $scope.repository = $scope.repositoryName;
+      $log.log('tag-controller: $scope.repositoryUser was undefined; setting repository to just repositoryName = ' + $scope.repository);
+    } else {
+      $scope.repository = $scope.repositoryUser + '/' + $scope.repositoryName;
+      $log.log('tag-controller: $scope.repositoryUser was NOT undefined; setting repository to ' + $scope.repository);
+    }
     $scope.tagName = $route.current.params.tagName;
     $scope.tagsPerPage = $route.current.params.tagsPerPage;
 

--- a/app/tag/tag-controller.js
+++ b/app/tag/tag-controller.js
@@ -8,8 +8,8 @@
  * Controller of the docker-registry-frontend
  */
 angular.module('tag-controller', ['registry-services'])
-  .controller('TagController', ['$scope', '$route', '$routeParams', '$location', '$log', '$filter', 'Manifest', 'Tag', 'filterFilter', '$modal',
-  function($scope, $route, $routeParams, $location, $log, $filter, Manifest, Tag, filterFilter, $modal){
+  .controller('TagController', ['$scope', '$route', '$routeParams', '$location', '$filter', 'Manifest', 'Tag', 'AppMode', 'filterFilter', '$modal',
+  function($scope, $route, $routeParams, $location, $filter, Manifest, Tag, AppMode, filterFilter, $modal){
 
     $scope.$route = $route;
     $scope.$location = $location;
@@ -18,16 +18,20 @@ angular.module('tag-controller', ['registry-services'])
     $scope.searchName = $route.current.params.searchName;
     $scope.repositoryUser = $route.current.params.repositoryUser;
     $scope.repositoryName = $route.current.params.repositoryName;
-    $log.log('tag-controller: $scope.repositoryUser = ' + $scope.repositoryUser);
     if ($scope.repositoryUser == null || $scope.repositoryUser == 'undefined') {
       $scope.repository = $scope.repositoryName;
-      $log.log('tag-controller: $scope.repositoryUser was undefined; setting repository to just repositoryName = ' + $scope.repository);
     } else {
       $scope.repository = $scope.repositoryUser + '/' + $scope.repositoryName;
-      $log.log('tag-controller: $scope.repositoryUser was NOT undefined; setting repository to ' + $scope.repository);
     }
     $scope.tagName = $route.current.params.tagName;
-    $scope.tagsPerPage = $route.current.params.tagsPerPage;
+    AppMode.query(function(result) {
+      $scope.appMode = result;
+      console.log('$route.current.params.tagsPerPage = ' + $route.current.params.tagsPerPage);
+      $scope.tagsPerPage = $route.current.params.tagsPerPage || $scope.appMode.defaultTagsPerPage;
+      if ($scope.tagsPerPage == 'all') {
+        $scope.tagsPerPage = null;
+      }
+    });
 
     // Fetch tags
     $scope.tags = Tag.query({

--- a/app/tag/tag-detail.html
+++ b/app/tag/tag-detail.html
@@ -26,8 +26,8 @@
 
 </h1>
 
-<div class="well">
+<div class="well"><code>
   docker pull {{registryHost.host}}<span ng-if="registryHost.port != 80 && registryHost.port != 443">:{{registryHost.port}}</span>/{{repository}}:{{tagName}}
-</div>
+</code></div>
 
 <image-details></image-details>

--- a/app/tag/tag-detail.html
+++ b/app/tag/tag-detail.html
@@ -1,17 +1,17 @@
 <ol class="breadcrumb">
     <li><a href="home">Home</a></li>
     <li><a href="repositories/">Repositories</a></li>
-    <li><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
-    <li><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a></li>
-    <li><a href="tag/{{repositoryUser}}/{{repositoryName}}/{{tagName}}/{{imageId}}">{{tagName}}</a></li>
+    <li ng-show="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></li>
+    <li><a href="repository/{{repository}}">{{repositoryName}}</a></li>
+    <li><a href="tag/{{repository}}/{{tagName}}/{{imageId}}">{{tagName}}</a></li>
 </ol>
 
 <h1>
-  Details for tag 
+  Details for tag
   <a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a> /
   <a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a> :
   <a href="tag/{{repositoryUser}}/{{repositoryName}}/{{tagName}}/{{imageId}}">{{tagName}}</a>
-  
+
   <div ng-hide="appMode.browseOnly" class="pull-right">
     <button type="button" ng-click="selection=['{{repositoryUser}}/{{repositoryName}}:{{tagName}}']; openConfirmTagDeletionDialog()" class="btn btn-danger">
       <span class="glyphicon glyphicon-trash"></span> Delete Tag

--- a/app/tag/tag-detail.html
+++ b/app/tag/tag-detail.html
@@ -27,7 +27,7 @@
 </h1>
 
 <div class="well">
-  docker pull {{registryHost.host}}<span ng-if="registryHost.port != 80 && registryHost.port != 443">:{{registryHost.port}}</span>/{{repositoryUser}}/{{repositoryName}}:{{tagName}}
+  docker pull {{registryHost.host}}<span ng-if="registryHost.port != 80 && registryHost.port != 443">:{{registryHost.port}}</span>/{{repository}}:{{tagName}}
 </div>
 
 <image-details></image-details>


### PR DESCRIPTION
This makes it so that images that don't have a user (e.g.: `ubuntu` rather than `gliderlabs/registrator`) work properly.

There have been several PRs I think that tried to tackle this (e.g.:  #100 , #104 & #97), but this one has tests (see https://github.com/kwk/docker-registry-frontend/pull/147/commits/9cb8ea158810371b057f43e324eb59536cd50456)! 😄 

Note that this changes the routing in a fairly significant way, because it switches to using query string variables for things like `tagsPerPage` and `tagPage`. The reason is that this helps to make the routes less ambiguous. For example, with the old routing, if you had a URI like `/repository/ubuntu/10` (the intent is that this means no user, image name is `ubuntu`, 10 tags per page), the routing could easily get confused and match a route like `/repository/:repositoryUser/:repositoryName`  and think that `repositoryUser` is `ubuntu` and `repositoryName` is `10`. Switching to query string variables removes this ambiguity, because `?tagsPerPage=10` makes it clear that the `10` is the number of tags per page and not the repository name.

Fixes #121 
Closes #97, #100, #104
