### PR TITLE
Remove unused RepositoryController route

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -68,10 +68,6 @@ angular
         templateUrl: 'repository/repository-detail.html',
         controller: 'RepositoryDetailController'
       }).
-      when('/repository/:repositoryUser/:repositoryName/tags/:searchName?', {
-        templateUrl: 'repository/repository-detail.html',
-        controller: 'RepositoryController',
-      }).
 	    when('/about', {
         templateUrl: 'about.html',
       }).


### PR DESCRIPTION
as far as I can tell, there is no `RepositoryController` controller, so this route is not useful.
