### PR TITLE
Display image details from Manifest v2 schema 2 (fixes #128)

### DIFF
--- a/app/image/image-controller.js
+++ b/app/image/image-controller.js
@@ -8,39 +8,15 @@
  * Controller of the docker-registry-frontend
  */
 angular.module('image-controller', ['registry-services', 'app-mode-services'])
-  .controller('ImageController', ['$scope', '$route', '$routeParams', '$location', '$log', '$filter', 'Manifest', 'AppMode',
-  function($scope, $route, $routeParams, $location, $log, $filter, Manifest, AppMode){
-    
+  .controller('ImageController', ['$scope', '$route', '$routeParams', '$location', '$log', '$filter', 'Manifest', 'Blob', 'AppMode',
+  function($scope, $route, $routeParams, $location, $log, $filter, Manifest, Blob, AppMode){
 
     $scope.appMode = AppMode.query();
-    $scope.totalImageSize = 0;
-    $scope.imageDetails = Manifest.query({repoUser: $scope.repositoryUser, repoName: $scope.repositoryName, tagName: $scope.tagName});
-    
+    $scope.details = Manifest.query({repoUser: $scope.repositoryUser, repoName: $scope.repositoryName, tagName: $scope.tagName});
 
+    $scope.config = {};
+    $scope.details.$promise.then(function(data) {
+      $scope.config = Blob.query({repoUser: $scope.repositoryUser, repoName: $scope.repositoryName, digest: data.config.digest});
+    });
 
-
-    // This is not totally working right now (problem with big layers)
-    /**
-     * Calculates the total download size for the image based on
-     * it's layers.
-     */
-    /*
-    $scope.totalImageSize = null;
-    $scope.calculateTotalImageSize = function() {
-      $scope.totalImageSize = 0;
-      var size;
-      angular.forEach($scope.imageDetails.fsLayers, function (id, key) {
-
-        Blob.query({repoUser: $scope.repositoryUser, repoName: $scope.repositoryName, digest: id.blobSum}).$promise.then( function(data, headers){
-          size = data;
-          console.log(data)
-          console.log(size)
-          if(!isNaN(data.contentLength-0)){
-            $scope.totalImageSize += data.contentLength;
-          }
-        });
-      });
-    };
-    */
-    
   }]);

--- a/app/image/image-details-directive.html
+++ b/app/image/image-details-directive.html
@@ -1,7 +1,7 @@
 <h2>
   Image Details
   <div ng-hide="appMode.browseOnly" class="pull-right">
-    <a href="image/{{imageDetails.id}}/tag/{{repositoryUser}}/{{repositoryName}}" class="btn btn-default">
+    <a href="image/{{details.imageId}}/tag/{{repositoryUser}}/{{repositoryName}}" class="btn btn-default">
       <span class="glyphicon glyphicon-plus"></span>
       Create a tag for this image
     </a>
@@ -14,74 +14,48 @@
       General information
     </tab-heading>
     <form class="form-horizontal"  role="form">
-      <div class="form-group">
-        <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-user"></span> Author</label>
-        <div class="col-sm-10">
-          <p class="form-control-static">{{imageDetails.author}}</p>
-        </div>
-      </div>
-      <div class="form-group" ng-if="imageDetails.comment">
-        <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-comment"></span> Comment</label>
-        <div class="col-sm-10">
-          <p class="form-control-static">
-            <pre>{{imageDetails.comment}}</pre>
-          </p>
-        </div>
-      </div>
-      <div class="form-group" >
+      <div class="form-group" ng-show="config.created">
         <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-calendar"></span> Created</label>
         <div class="col-sm-10">
           <p class="form-control-static">
-            <span am-time-ago="imageDetails.created"></span>
-            <span class="text-muted"> ({{imageDetails.created | date:'yyyy-MM-dd HH:mm:ss Z'}})</span>
+            <span am-time-ago="config.created"></span>
+            <span class="text-muted"> ({{config.created | date:'yyyy-MM-dd HH:mm:ss Z'}})</span>
           </p>
         </div>
       </div>
-      <div class="form-group">
+      <div class="form-group" ng-show="config.docker_version">
         <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-eye-open"></span> Docker version</label>
         <div class="col-sm-10">
-          <p class="form-control-static">{{imageDetails.docker_version}}</p>
+          <p class="form-control-static">{{config.docker_version}}</p>
         </div>
       </div>
-      <div class="form-group">
+      <div class="form-group" ng-show="config.os">
         <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-cog"></span> OS</label>
         <div class="col-sm-10">
-          <p class="form-control-static">{{imageDetails.os}}/{{imageDetails.architecture}}</p>
+          <p class="form-control-static">{{config.os}}/{{config.architecture}}</p>
         </div>
       </div>
       <div class="form-group">
-        <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-qrcode"></span> ID</label>
+        <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-qrcode"></span> Image ID</label>
         <div class="col-sm-10">
           <p class="form-control-static">
-            {{imageDetails.id | limitTo: 12}}
+            {{details.imageId | limitTo: 12}}
           </p>
         </div>
       </div>
-     <!--  <div class="form-group">
-        <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-arrow-up"></span> Parent's layer ID</label>
-        <div class="col-sm-10">
-          <p class="form-control-static">
-            {{imageDetails.parentLayer | limitTo: 12}}
-          </p>
-        </div>
-      </div> -->
-      
-<!--       <div class="form-group">
+      <div class="form-group">
         <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-compressed"></span> Size <small>(including base image sizes)</small></label>
         <div class="col-sm-10">
           <p class="form-control-static">
-            <span ng-show="totalImageSize!==null">
-              {{totalImageSize/1024/1024 | number: 2}} <b>MB</b> {{totalImageSize / 1024 | number: 2}} <b>KB</b> {{totalImageSize}} <b>B</b>
+            <span>
+              {{details.size / 1024 / 1024 | number: 2}} <b>MB</b>
             </span>
-            <button type="submit" class="btn btn-info" ng-click="calculateTotalImageSize()" ng-show="totalImageSize===null">
-              <span class="glyphicon glyphicon-stats"></span> Calculate
-            </button>
           </p>
         </div>
-      </div> --> 
+      </div>
     </form>
   </tab>
-  <tab>
+  <tab ng-show="config.container_config.Labels.length">
     <tab-heading>
       Labels
     </tab-heading>
@@ -93,12 +67,22 @@
           </tr>
         </thead>
         <tbody>
-          <tr ng-repeat="(key, value) in imageDetails.labels">
+          <tr ng-repeat="(key, value) in config.container_config.Labels">
             <td>{{key}}</td>
             <td>{{value}}</td>
           </tr>
         </tbody>
       </table>
+  </tab>
+  <tab ng-show="config.dockerfile.length">
+    <tab-heading>
+      Dockerfile
+    </tab-heading>
+    <pre>
+      <code ng-repeat="instruction in config.dockerfile">
+{{instruction}}
+      </code>
+    </pre>
   </tab>
 </tabset>
 

--- a/app/services/registry-services.js
+++ b/app/services/registry-services.js
@@ -146,82 +146,81 @@ angular.module('registry-services', ['ngResource'])
     return $resource('/v2/:repoUser/:repoName/manifests/:tagName', {}, {
       // Response example:
       // {
-      //   "schemaVersion": 1,
-      //   "name": "arthur/busybox",
-      //   "tag": "demo",
-      //   "architecture": "amd64",
-      //   "fsLayers": [
+      //   "schemaVersion": 2,
+      //   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      //   "config": {
+      //     "mediaType": "application/vnd.docker.container.image.v1+json",
+      //     "size": 7963,
+      //     "digest": "sha256:1f1e1ccbb0918e4b08f877035831d178a6c34aeec58cfe2dc6014557b2e8ec13"
+      //   },
+      //   "layers": [
       //     {
-      //       "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      //       "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      //       "size": 52550276,
+      //       "digest": "sha256:cd0a524342efac6edff500c17e625735bbe479c926439b263bbe3c8518a0849c"
       //     },
       //     {
-      //       "blobSum": "sha256:d7e8ec85c5abc60edf74bd4b8d68049350127e4102a084f22060f7321eac3586"
+      //       "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      //       "size": 78849205,
+      //       "digest": "sha256:14b8a88a0af049efa3c92b1c96a947f501ec7c751a568b0d3881b3c757a184a3"
       //     }
-      //   ],
-      //   "history": [
-      //     {
-      //       "v1Compatibility": "{\"id\":\"3e1018ee907f25aef8c50016296ab33624796511fdbfdbbdeca6a3ed2d0ba4e2\",\"parent\":\"176dfc9032a1ec3ac8586b383e325e1a65d1f5b5e6f46c2a55052b5aea8310f7\",\"created\":\"2016-01-12T17:47:39.251310827Z\",\"container\":\"2732d16efa11ab7da6393645e85a7f2070af94941a782a69e86457a2284f4a69\",\"container_config\":{\"Hostname\":\"ea7fe68f39fd\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) LABEL awesome=Not yet!\"],\"Image\":\"176dfc9032a1ec3ac8586b383e325e1a65d1f5b5e6f46c2a55052b5aea8310f7\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{\"awesome\":\"Not yet!\",\"test\":\"yes\",\"working\":\"true\"}},\"docker_version\":\"1.9.1\",\"author\":\"Arthur\",\"config\":{\"Hostname\":\"ea7fe68f39fd\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"sh\"],\"Image\":\"176dfc9032a1ec3ac8586b383e325e1a65d1f5b5e6f46c2a55052b5aea8310f7\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{\"awesome\":\"Not yet!\",\"test\":\"yes\",\"working\":\"true\"}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
-      //     },
-      //     {
-      //       "v1Compatibility": "{\"id\":\"5c5fb281b01ee091a0fffa5b4a4c7fb7d358e7fb7c49c263d6d7a4e35d199fd0\",\"created\":\"2015-12-08T18:31:50.979824705Z\",\"container\":\"ea7fe68f39fd0df314e841247fb940ddef4c02ab7b5edb0ee724adc3174bc8d9\",\"container_config\":{\"Hostname\":\"ea7fe68f39fd\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:c295b0748bf05d4527f500b62ff269bfd0037f7515f1375d2ee474b830bad382 in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.3\",\"config\":{\"Hostname\":\"ea7fe68f39fd\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":1113436}"
-      //     }
-      //   ],
+      //   ]
       // }
       'query': {
         method:'GET',
-        isArray: false,
+        headers: {
+          accept: 'application/vnd.docker.distribution.manifest.v2+json',
+        },
         transformResponse: function(data, headers){
-          var res = {};
-          var history = [];
-          var tmp;
-          var resp = angular.fromJson(data);
-          var v1Compatibility = undefined;
+          data = angular.fromJson(data);
+          data.digest = headers('docker-content-digest');
+          data.imageId = data.config.digest.replace(/^sha256:/, '');
+          data.size = data.layers.reduce(function(size, layer) {
+            return size + layer.size;
+          }, data.config.size);
 
-          for (var idx in resp.history){
-
-            v1Compatibility = angular.fromJson(resp.history[idx].v1Compatibility);
-
-            if(v1Compatibility !== undefined){
-              tmp = {
-                id : v1Compatibility.id,
-                os : v1Compatibility.os,
-                docker_version: v1Compatibility.docker_version,
-                created: v1Compatibility.created,
-                // parentLayer: v1Compatibility.parent
-              };
-              if(v1Compatibility.author){
-                tmp.author = v1Compatibility.author;
-              }
-              if(v1Compatibility.config && v1Compatibility.config.Labels){
-                tmp.labels = v1Compatibility.config.Labels;
-              }
-              history.push(tmp);
-            }
-          }
-          if(history.length > 0){
-            res = history[0];
-            res.history = history;
-          }
-          res.fsLayers = resp.fsLayers;
-          res.digest = headers('docker-content-digest');
-          res.architecture = resp.architecture;
-          return res;
+          return data;
         },
       }
     });
   }])
-  // This is not totally working right now (problem with big layers)
-  /*
   .factory('Blob', ['$resource', function($resource){
     return $resource('/v2/:repoUser/:repoName/blobs/:digest', {}, {
-
+    // {
+    //   "architecture": "amd64",
+    //   "config": {},
+    //   "container": "caab3f21c75adc3560754e71374cd01cb1bbe39b2b9c2809ff6c22bbcd39206c",
+    //   "container_config": {},
+    //   "created": "2017-04-25T03:44:24.620936172Z",
+    //   "docker_version": "17.04.0-ce",
+    //   "history": [
+    //     {
+    //       "created": "2017-04-24T19:20:41.290148217Z",
+    //       "created_by": "/bin/sh -c #(nop) ADD file:712c48086043553b85ffb031d8f6c5de857a2e53974df30cdfbc1e85c1b00a25 in / "
+    //     },
+    //     {
+    //       "created": "2017-04-24T19:20:42.022627269Z",
+    //       "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+    //       "empty_layer": true
+    //     }
+    //   ],
+    //   "os": "linux",
+    //   "rootfs": {}
+    // }
       'query': {
-        method:'HEAD',
-        interceptor: function(data, headers){
-          var res = {contentLength: parseInt(headers('content-length'))};
-          return res;
-        } 
+        method: 'GET',
+        transformResponse: function(data, headers){
+          data = angular.fromJson(data);
+          data.dockerfile = data.history.map(function(history) {
+            return history.created_by
+              .replace(new RegExp('^/bin/sh -c #\\(nop\\)\\s*'), '')
+              .replace(new RegExp('^/bin/sh -c\\s*'), 'RUN ')
+              .replace(/\t\t/g, '\\\n\t');
+          });
+
+          return data;
+        }
       }
 
     });
-  }]) */ ;
+  }]);

--- a/app/tag/tag-list-directive.html
+++ b/app/tag/tag-list-directive.html
@@ -11,12 +11,8 @@
     <thead>
       <tr>
         <th  ng-class="{strike: deleted}"><span class="glyphicon glyphicon-tag"></span> Tag</th>
-        <th ><span class="glyphicon glyphicon-qrcode"></span> Image ID</th>
-        <th ><span class="glyphicon glyphicon-calendar"></span> Created</th>
-        <th ><span class="glyphicon glyphicon-user"></span> Author</th>
-        <th ><span class="glyphicon glyphicon-eye-open"></span> Docker version</th>
-        <!-- <th ><span class="glyphicon glyphicon-arrow-up"></span> Parent's ID</th> -->
-        <!-- <th><span class="glyphicon glyphicon-compressed"></span> Size (MB)</th> -->
+        <th><span class="glyphicon glyphicon-qrcode"></span> Image ID</th>
+        <th><span class="glyphicon glyphicon-compressed"></span> Size (MB)</th>
       </tr>
       <tr>
   			<th><input class="input-sm form-control" placeholder="Filter tags on this page" type="search" ng-model="search.name"/></th>
@@ -27,20 +23,8 @@
         <td>
           <a ng-bind-html="tag.name" href="tag/{{repositoryUser}}/{{repositoryName}}/{{tag.name}}">{{tag.name}}</a>
         </td>
-        <td><span ng-bind-html="tag.details.id | limitTo: 12"></span></td>
-        <td am-time-ago="tag.details.created"></td>
-        <td><span ng-bind-html="tag.details.author | linky"></span></td>
-        <td ng-bind-html="tag.details.docker_version"></td>
-        <!-- <td><span ng-bind-html="tag.details.parent | limitTo: 12"></span></td> -->
-        <!-- <td>
-          <button type="submit" class="btn btn-info btn-xs" ng-click="calculateTotalImageSize()" ng-show="totalImageSize===null" title="Calculate total image size">
-            <span class="glyphicon glyphicon-stats"></span>
-          </button>
-          <span  ng-show="totalImageSize===null" ng-bind-html="tag.details.Size / 1024 / 1024 | number: 2"></span>
-          <span ng-show="totalImageSize!==null">
-            {{totalImageSize / 1024 / 1024 | number: 2}}
-          </span>
-        </td> -->
+        <td><span ng-bind-html="tag.details.imageId | limitTo: 12"></span></td>
+        <td>{{tag.details.size / 1024 / 1024 | number: 2}}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
I borrowed ideas from https://github.com/kwk/docker-registry-frontend/pull/101 and made the API requests with `application/vnd.docker.distribution.manifest.v2+json` but without `v1Compatibility`.
Useful description: https://github.com/docker/distribution/issues/1252#issuecomment-274944254

This PR conflicts with https://github.com/kwk/docker-registry-frontend/pull/167 and the rebase is required before merge.

Issue for reference #128 