### PR TITLE
feat(maintainer-label): display maintainer label as author

### DIFF
--- a/app/image/image-details-directive.html
+++ b/app/image/image-details-directive.html
@@ -17,7 +17,7 @@
       <div class="form-group">
         <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-user"></span> Author</label>
         <div class="col-sm-10">
-          <p class="form-control-static">{{imageDetails.author}}</p>
+          <p class="form-control-static">{{imageDetails.labels.maintainer || imageDetails.author}}</p>
         </div>
       </div>
       <div class="form-group" ng-if="imageDetails.comment">
@@ -65,7 +65,7 @@
           </p>
         </div>
       </div> -->
-      
+
 <!--       <div class="form-group">
         <label class="col-sm-2 control-label"><span class="glyphicon glyphicon-compressed"></span> Size <small>(including base image sizes)</small></label>
         <div class="col-sm-10">
@@ -78,7 +78,7 @@
             </button>
           </p>
         </div>
-      </div> --> 
+      </div> -->
     </form>
   </tab>
   <tab>

--- a/app/tag/tag-list-directive.html
+++ b/app/tag/tag-list-directive.html
@@ -29,7 +29,7 @@
         </td>
         <td><span ng-bind-html="tag.details.id | limitTo: 12"></span></td>
         <td am-time-ago="tag.details.created"></td>
-        <td><span ng-bind-html="tag.details.author | linky"></span></td>
+        <td><span ng-bind-html="(tag.details.labels.maintainer || tag.details.author) | linky"></span></td>
         <td ng-bind-html="tag.details.docker_version"></td>
         <!-- <td><span ng-bind-html="tag.details.parent | limitTo: 12"></span></td> -->
         <!-- <td>


### PR DESCRIPTION
Docker considers the `MAINTAINER` instruction as [deprecated](https://docs.docker.com/v17.03/engine/reference/builder/#maintainer-deprecated) and suggests to move the maintainer information to the labels.

This pull request implements support for both variants and prefers the maintainer label if available.