### PR TITLE
Issue 75 fix - allow all HTTP methods to pass through registry proxy

### DIFF
--- a/apache-site.conf
+++ b/apache-site.conf
@@ -33,6 +33,9 @@
         Deny From All
       </LimitExcept>
     </Location>
+    <Location /v2>
+        Allow From All
+    </Location>
   </IfDefine>
 
   # Proxy all docker REST API registry


### PR DESCRIPTION
Regarding the [closed issue #75 - Can't push when using frontend as registry](https://github.com/kwk/docker-registry-frontend/issues/75) it seems there is still an issue to @jangrewe's point...

Noticing the Apache config is designed to allow proxying _v2_ straight through to the registry:
```
  # Proxy all docker REST API registry
  # requests to the docker registry server.

  <IfModule ssl_module>
     SSLProxyEngine on
     # SSLProxyVerify none
     SSLProxyCheckPeerCN off
     SSLProxyCheckPeerName off
  </IfModule>
  ProxyPreserveHost Off
  ProxyPass /v2/ ${DOCKER_REGISTRY_SCHEME}://${DOCKER_REGISTRY_HOST}:${DOCKER_REGISTRY_PORT}/v2/
  ProxyPassReverse /v2/ ${DOCKER_REGISTRY_SCHEME}://${DOCKER_REGISTRY_HOST}:${DOCKER_REGISTRY_PORT}/v2/
```

And that I could pull, but not push, because of the `FRONTEND_BROWSE_ONLY_MODE` HTTP GET restriction:
```
  <IfDefine FRONTEND_BROWSE_ONLY_MODE>
    <Location />
      <LimitExcept GET>
        Order Allow,Deny
        Deny From All
      </LimitExcept>
    </Location>
  </IfDefine>
```
It seems only fair to allow all HTTP methods to flow through the `/v2/` proxy (which is what I've added in this patch).

I've tested the change in my environment and pushes now work through the frontend. FWIW, I spent hours trying to figure out what was wrong... At the very least if this patch isn't accepted, something should be added to the README explaining that pushes aren't supported through the frontend, though I'm unsure why you'd want to prohibit them.