### PR TITLE
Update development Dockerfile to official Node 8 image

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -1,7 +1,19 @@
-FROM ubuntu:14.04
+FROM node:8-alpine
 MAINTAINER "Konrad Kleine"
 
 USER root
+
+# The node image removes these packages as they are only needed to build node not to run it
+# Since we update npm package at start up will need these in the image
+RUN apk add --no-cache \
+  bash \
+  curl \
+  gcc \
+  g++ \
+  git \
+  make \
+  nano \
+  python
 
 ############################################################
 # Setup environment variables
@@ -9,39 +21,6 @@ USER root
 
 ENV SOURCE_DIR /source
 ENV START_SCRIPT /root/start-develop.sh
-
-############################################################
-# Speedup DPKG and don't use cache for packages
-############################################################
-
-# Taken from here: https://gist.github.com/kwk/55bb5b6a4b7457bef38d
-#
-# this forces dpkg not to call sync() after package extraction and speeds up
-# install
-RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup
-# we don't need and apt cache in a container
-RUN echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache
-
-RUN apt-get -y update && \
-    export DEBIAN_FRONTEND=noninteractive
-
-############################################################
-# Install development requirements
-############################################################
-
-RUN apt-get -y install \
-      git \
-      nodejs \
-      nodejs-legacy \
-      npm \
-      --no-install-recommends
-RUN git config --global url."https://".insteadOf git://
-# Avoid this: "Problem with the SSL CA cert (path? access rights?)"
-RUN git config --global http.sslVerify false
-
-############################################################
-# Create start script
-############################################################
 
 # Let people know how this was built
 ADD Dockerfile /root/Dockerfile


### PR DESCRIPTION
The existing development `Dockerfile` was an Ubuntu image which installed Node and NPM via
`apt-get`. This change set updates the `Dockerfile` to use the official Node
image which has the chosen version of Node and NPM pre-installed.

It also switches to an Alpine image to lower the file size.