### PR TITLE
Update development docker-compose to v3 syntax

### DIFF
--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -1,16 +1,28 @@
-frontend:
-  build: .
-  links:
-    - registry:path-to-your-registry-v2
-  ports:
-      # Serves the page via grunt
-    - "9000:9000"
-      # For live reload with grunt
-    - "35729:35729"
-  volumes:
-    - ../:/source:rw
-    - ./start-develop.sh:/root/start-develop.sh:ro
-registry:
-  image: registry:2.1.1
-  ports:
-    - "5000:5000"
+version: '3.2'
+services:
+  frontend:
+    build: .
+    ports:
+        # Serves the page via grunt
+      - "9000:9000"
+        # For live reload with grunt
+      - "35729:35729"
+    depends_on:
+      - registry
+    volumes:
+      - ../:/source:rw
+      - ./start-develop.sh:/root/start-develop.sh:ro
+    environment:
+      - DOCKER_REGISTRY_HOST=registry
+      - DOCKER_REGISTRY_PORT=5000
+  registry:
+    image: registry:2.1.1
+    expose:
+      - "5000"
+    networks:
+      dev_net:
+        aliases:
+          - path-to-your-registry-v2
+
+networks:
+  dev_net:


### PR DESCRIPTION
This change set updates the docker-compose file in the develop folder to use
the v3 syntax. This allows us to add a user layer network so that the two
containers can communicate without having to go up the network stack. This
allows us to not have to expose the registry's port (5000) to the host.

This reduces the chance of a port conflict