### PR TITLE
Change landing page to repositories

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -84,6 +84,6 @@ angular
         controller: 'CreateTagController',
       }).
       otherwise({
-        redirectTo: '/home'
+        redirectTo: '/repositories/20'
       });
   }]);

--- a/app/app.spec.js
+++ b/app/app.spec.js
@@ -159,12 +159,12 @@ describe('docker-registry-frontend', function() {
     expect($route.current.controller).toBe('CreateTagController');
   });
 
-  it('/unknown-url should display home page', function() {
-    $httpBackend.expectGET('home.html').respond(200);
+  it('/unknown-url should display repositories page', function() {
+    $httpBackend.expectGET('repository/repository-list.html').respond(200);
     $location.path('/unknown-url');
     $rootScope.$digest();
-    expect($route.current.templateUrl).toBe('home.html');
-    expect($route.current.controller).toBe('HomeController');
+    expect($route.current.templateUrl).toBe('repository/repository-list.html');
+    expect($route.current.controller).toBe('RepositoryListController');
   });
 
 });


### PR DESCRIPTION
Currently the landing page is the home page but that requires the user to make
one mouse click to navigate to the repositories page which is where the action
is. This change set just updates the default landing route from Home to
repositories (with a default page of 20). The Home page still exists but is not
the default location the user lands on when going to the site.

This fixes issues #34