### PR TITLE
 🐛Fix tag links navigating to home

### DIFF
--- a/app/tag/tag-detail.html
+++ b/app/tag/tag-detail.html
@@ -8,9 +8,11 @@
 
 <h1>
   Details for tag
-  <a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a> /
-  <a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a> :
-  <a href="tag/{{repositoryUser}}/{{repositoryName}}/{{tagName}}/{{imageId}}">{{tagName}}</a>
+  <span ng-show="repositoryUser"><a href="repositories/{{repositoryUser}}">{{repositoryUser}}</a></span> /
+  <span ng-show="repositoryUser"><a href="repository/{{repositoryUser}}/{{repositoryName}}">{{repositoryName}}</a></span>
+  <span ng-hide="repositoryUser"><a href="repository/{{repositoryName}}">{{repositoryName}}</a></span> :
+  <span ng-show="repositoryUser"><a href="tag/{{repositoryUser}}/{{repositoryName}}/{{tagName}}/{{imageId}}">{{tagName}}</a></span>
+  <span ng-hide="repositoryUser"><a href="tag/{{repositoryName}}/{{tagName}}/{{imageId}}">{{tagName}}</a></span>
 
   <div ng-hide="appMode.browseOnly" class="pull-right">
     <button type="button" ng-click="selection=['{{repositoryUser}}/{{repositoryName}}:{{tagName}}']; openConfirmTagDeletionDialog()" class="btn btn-danger">


### PR DESCRIPTION
Some of the tag links when clicked would take you to the default page (i.e. home view). 
This only happened on images which didn't have
a user prefix (i.e. `nginx` vs. `my/nginx`).

This happened because the links were built expecting the prefix so the URL
was `//nginx` but that was not routed properly so the user fell into the catch
other _otherwise_ handler which took them to the repositories view.

This change set fixes that by building the links with URLs that include the
prefix if it exists or without the prefix if the image does not have a user
prefix.